### PR TITLE
GPAW with DFT-D3 and test fixes

### DIFF
--- a/gpaw/examples/mahti/build_gpaw_rhel8.sh
+++ b/gpaw/examples/mahti/build_gpaw_rhel8.sh
@@ -55,6 +55,7 @@ fi
 
 tmp=$TMPDIR/gpaw_build
 tmp_gpaw_git=$tmp/gpaw
+tmp_dftd3=$tmp/dftd3
 rm -rf $tmp
 # trap "rm -rf $tmp" EXIT
 
@@ -98,6 +99,16 @@ popd
 
 # Install pytest: don't do it! Otherwise pytest prepends this path to sys.path when run -> big mess with other modules!
 # $python -m pip install --prefix $install_tgt pytest
+
+# Install DFTD3
+mkdir -p $tmp_dftd3
+pushd $tmp_dftd3
+wget https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3/dftd3.tgz
+tar xf dftd3.tgz
+make 2>&1 | tee $install_tgt/dftd3.log
+cp -v dftd3 $install_tgt/bin/
+popd
+
 
 # Create the module
 depend_clause=""

--- a/gpaw/pytest.sh
+++ b/gpaw/pytest.sh
@@ -110,4 +110,5 @@ for n in 1 2 4 8; do
     tests="test/vdw/"
     submit_job "gpaw_pytest_n$n" "$n" "pytest -vs" "$tests"
     submit_job "gpaw_pytest_n$n-gp" "$n" "gpaw-python -m pytest -vs" "$tests"
+    # TODO: some tests are triggered only with export GPAW_NEW=1
 done

--- a/gpaw/pytest.sh
+++ b/gpaw/pytest.sh
@@ -79,6 +79,9 @@ function submit_job {
     cache_dir=$run_dir/pytest_cache
     tmp_dir=$run_dir/pytest_tmp
 
+    # Hack around https://gitlab.com/gpaw/gpaw/-/issues/1441: some tests use
+    # subprocesses and fail depending on MPI configuration. They are all
+    # serial tests, so we can just run them without srun
     sbatch_args="--mem-per-cpu=4G"
     srun="srun"
     if [[ $n -eq 1 ]]; then

--- a/gpaw/pytest.sh
+++ b/gpaw/pytest.sh
@@ -80,8 +80,10 @@ function submit_job {
     tmp_dir=$run_dir/pytest_tmp
 
     sbatch_args="--mem-per-cpu=4G"
+    srun="srun"
     if [[ $n -eq 1 ]]; then
         sbatch_args="--mem-per-cpu=8G"
+        srun=""
     fi
 
     rm -rf $run_dir
@@ -91,7 +93,7 @@ function submit_job {
     ln -s $(readlink -f $test_dir) ./
     mkdir -p $cache_dir/d
     ln -s $(readlink -f $gpw_files) $cache_dir/d/
-    sbatch -J $name -o slurm.out -t 04:00:00 -N 1 -n $n --cpus-per-task=1 -p small $sbatch_args --wrap="gpaw info; srun $cmd --disable-pytest-warnings -o cache_dir=$cache_dir --basetemp=$tmp_dir $tests; rm -rf $tmp_dir"
+    sbatch -J $name -o slurm.out -t 04:00:00 -N 1 -n $n --cpus-per-task=1 -p small $sbatch_args --wrap="gpaw info; $srun $cmd --disable-pytest-warnings -o cache_dir=$cache_dir --basetemp=$tmp_dir $tests; rm -rf $tmp_dir"
     popd
 }
 


### PR DESCRIPTION
This PR will:
- Run serial tests without `srun` (see https://gitlab.com/gpaw/gpaw/-/issues/1441)
- Install DFT-D3 with the same recipe as in Niflheim (see `gpaw_venv.py` here https://gpaw.readthedocs.io/platforms/Linux/Niflheim/build.html)
- Add a note to check/run tests with GPAW_NEW for the next installation, see e.g. [this test](https://gitlab.com/gpaw/gpaw/-/blob/b55c89f634a4b7352d149514e862c74473dd437c/gpaw/test/test_d3_extension.py#L13) 